### PR TITLE
Issues fix and feature enhancements

### DIFF
--- a/layout/components/head.jsx
+++ b/layout/components/head.jsx
@@ -207,8 +207,10 @@ module.exports = function Head(props) {
             <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
             <meta name="HandheldFriendly" content="true"/>
             <meta name="apple-mobile-web-app-capable" content="yes"/>
+            <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
             <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-            <meta name="theme-color" content="#f8f8f8"/>
+            <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8f8f8"/>
+            <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e"/>
 
             <Title {...props}/>
             <OpenGraph {...props}/>

--- a/layout/components/head.jsx
+++ b/layout/components/head.jsx
@@ -210,7 +210,9 @@ module.exports = function Head(props) {
             <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
             <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
             <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8f8f8"/>
-            <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e"/>
+            {/** Higher priority than `#1a1f35`. */}
+            <meta name="theme-color" media="(prefers-color-scheme: dark) and (max-width: 667px)" content="#000000"/>
+            <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a1f35"/>
 
             <Title {...props}/>
             <OpenGraph {...props}/>

--- a/layout/components/main/article/article_footer.jsx
+++ b/layout/components/main/article/article_footer.jsx
@@ -53,7 +53,7 @@ const ArticleFooter = props => {
         let license
         if (page.layout === 'post') {
             if (theme.article.license?.length > 0) {
-                license = (page.license || theme.article.license)
+                license = (page.license ?? theme.article.license)
             }
         } else if (page.layout === 'wiki') {
             let proj = theme.wiki.tree[page.wiki]

--- a/layout/components/main/navbar/list_wiki.jsx
+++ b/layout/components/main/navbar/list_wiki.jsx
@@ -10,16 +10,19 @@ module.exports = function NavBarListWiki(props) {
                 {/*项目分类*/}
                 {(()=>{
                     const { shelf, all_tags } = theme.wiki;
+                    const result = [];
                     for (let id of Object.keys(all_tags)) {
                         let tag = all_tags[id];
                         let projects = tag.items.filter(item => shelf.includes(item))
                         if (projects && projects.length > 0) {
                             const isActive = (tag.name && tag.name.length > 0 && page.tagName === tag.name);
-                            return <a className={isActive ? "active" : ""} href={url_for(tag.path)}>
+                            return result.push(<a className={isActive ? "active" : ""} href={url_for(tag.path)}>
                                 {tag.name}
-                            </a>
+                            </a>);
                         }
                     }
+
+                    return result;
                 })()}
             </nav>
         </div>

--- a/layout/page.jsx
+++ b/layout/page.jsx
@@ -4,7 +4,7 @@ const ArticleFooter = require('./components/main/article/article_footer.jsx');
 const Comments = require('./components/plugins/comments/layout.jsx');
 const PageTitle = props => {
     const {page} = props;
-    const title = page.h1 || page.title;
+    const title = page.h1 ?? page.title;
     if (title && title.length > 0) {
         return <h1 className="article-title"><span>{title}</span></h1>;
     } else {

--- a/layout/page.jsx
+++ b/layout/page.jsx
@@ -29,7 +29,7 @@ const Page = props => {
     }
     elements.push(
         <article className={`md-text content ${page.layout} ${page.indent ? 'indent' : ''} ${scroll_reveal()}`}>
-            {page.h1 || page.title ? <PageTitle {...props}/> : <></>}
+            {page.h1 ?? page.title ? <PageTitle {...props}/> : <></>}
             {page.content ? <div dangerouslySetInnerHTML={{__html: page.content}}/> : <></>}
             <ArticleFooter {...props}/>
         </article>

--- a/layout/post.jsx
+++ b/layout/post.jsx
@@ -6,7 +6,7 @@ const RelatedPosts = require('./components/main/article/related_posts.jsx');
 const Comments = require('./components/plugins/comments/layout.jsx');
 const PostTitle = props => {
     const {page} = props;
-    const title = page.h1 || page.title;
+    const title = page.h1 ?? page.title;
     if (title && title.length > 0) {
         return <h1 className="article-title"><span>{title}</span></h1>;
     } else {

--- a/layout/wiki.jsx
+++ b/layout/wiki.jsx
@@ -6,7 +6,7 @@ const ReadNext = require('./components/main/article/read_next.jsx');
 const Comments = require('./components/plugins/comments/layout.jsx');
 const WikiTitle = props => {
     const {page} = props;
-    const title = page.h1 || page.title;
+    const title = page.h1 ?? page.title;
     if (title && title.length > 0) {
         return <h1 className="article-title"><span>{title}</span></h1>;
     } else {

--- a/source/css/_common/html.styl
+++ b/source/css/_common/html.styl
@@ -1,6 +1,7 @@
 *
   outline: none
 html
+  color-scheme: var(--color-scheme)
   font-family: $ff-body
   font-size: $fs-root
   -webkit-text-size-adjust: 100%

--- a/source/css/_custom.styl
+++ b/source/css/_custom.styl
@@ -17,6 +17,7 @@ $light-card = convert(hexo-config('style.color.light.card'))
 $light-title = convert(hexo-config('style.color.light.title'))
 $light-text = convert(hexo-config('style.color.light.text'))
 $light-code = convert(hexo-config('style.color.light.code'))
+$light-color-scheme = light
 
 // 深色
 $dark-background = convert(hexo-config('style.color.dark.background'))
@@ -28,6 +29,7 @@ $dark-card = convert(hexo-config('style.color.dark.card'))
 $dark-title = convert(hexo-config('style.color.dark.title'))
 $dark-text = convert(hexo-config('style.color.dark.text'))
 $dark-code = convert(hexo-config('style.color.dark.code'))
+$dark-color-scheme = dark
 
 // 移动端深色背景（OLED调成纯黑可以省电）
 $dark-background-mobile = convert(hexo-config('style.color.dark.background-mobile'))

--- a/source/css/_defines/theme.styl
+++ b/source/css/_defines/theme.styl
@@ -20,6 +20,7 @@ set_text_dark()
   --text-revert: $dark-title
 :root
   --site-bg: $light-background
+  --color-scheme: $light-color-scheme
   --card-border: $light-border
   --card: $light-card
   --block: $light-block
@@ -34,6 +35,7 @@ set_text_dark()
 set_darkmode()
   :root
     --site-bg: $dark-background
+    --color-scheme: $dark-color-scheme
     --card: $dark-card
     --card-border: $dark-border
     --block: $dark-block


### PR DESCRIPTION
1. feat(layout): enable to set h1 as empty string to avoid generate another `<h1 />` element
   在 _post/*.md 中可以设置 `h1: ''` 来让页面不生成额外的 `<h1 />` 元素。
   比如，`a.md` 里面内容为 `# 111`，`title: 111`，那么页面会有两个 `<h1>111</h1>`。
2. fix(layout): fix the issue that always shows only one tag for wiki index page
   修复 wiki index `xxx.yy.com/wiki/` 界面始终只显示一个 `tag` 的 issue。
3. chore(layout): enable to hide the license for posts
   在 `post` 类型 `*.md` 中，设置 `license: ''` 隐藏 `article footer` 里的 `license`。
4. style(source): enable to automatically set `html color-scheme`
5. chore(layout): enable to automatically set `theme-color`
   更好的深色模式体验，比如动态的 PWA 标题栏颜色，动态的 IOS-Safari 状态栏颜色。