### PR TITLE
fix: 修复目录层级错乱的问题

### DIFF
--- a/layout/components/widgets/toc.jsx
+++ b/layout/components/widgets/toc.jsx
@@ -1,8 +1,8 @@
-    const {Fragment} = require('react');
+const {Fragment} = require('react');
 const Toc = props => {
     const {theme, page, toc} = props;
     let proj = theme.wiki.tree[page.wiki];
-
+    const parse = require('html-react-parser').default;
     const LayoutToc = props => {
         const {toc, page} = props;
         const generatedToc = toc(page.content, {
@@ -11,12 +11,8 @@ const Toc = props => {
             max_depth: props.max_depth
         })
         if (generatedToc.length > 0) {
-            const renderedToc = generatedToc.replace('<ol class="toc">', '').replace('</ol>', '');
             return (
-                <ol className="toc"
-                     dangerouslySetInnerHTML={{__html: renderedToc}}
-                >
-                </ol>
+                <ol className="toc">{parse(generatedToc).props.children}</ol>
             )
         }
         return <></>;


### PR DESCRIPTION
通过引入 html-react-parser 二次解析解决

被逆天传奇 `</ol>` 替换为空法气晕.webp

