### PR TITLE
[fix] 默认开启侧边栏标题的遮挡

### DIFF
--- a/source/css/_components/widgets/widgets.styl
+++ b/source/css/_components/widgets/widgets.styl
@@ -19,7 +19,7 @@
       font-weight: 500
       position: sticky
       top: -2px
-      //background: var(--site-bg)
+      background: var(--site-bg)
       padding-top: 2px
       z-index 1
       .item 


### PR DESCRIPTION
取消//background: var(--site-bg)注释，使边栏标题默认就相互遮挡，以避免：

<img width="287" height="156" alt="image" src="https://github.com/user-attachments/assets/d497fa1f-4759-416a-ae55-1683f61aa72c" />

这样的情况出现


关于测试：

暂未发现这个更改影响其它组件，如有影响，请随时告知:)